### PR TITLE
Add `noplaybackrate` supported token to controlsList

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -111,15 +111,15 @@ tokens](https://dom.spec.whatwg.org/#concept-supported-tokens).
 
 Usage in HTML:
 ```html
-<video controls controlslist="nofullscreen nodownload noremoteplayback foobar"></video>
+<video controls controlslist="nofullscreen nodownload noremoteplayback noplaybackrate foobar"></video>
 ```
 
 Usage in Javascript:
 ```javascript
 var video = document.querySelector('video');
 video.controls; // true
-video.controlsList; // "nofullscreen nodownload noremoteplayback" - "foobar" not present
+video.controlsList; // "nofullscreen nodownload noremoteplayback noplaybackrate" - "foobar" not present
 video.controlsList.remove('noremoteplayback');
-video.controlsList; // "nofullscreen nodownload" - "noremoteplayback" not present
-video.getAttribute('controlslist'); // "nofullscreen nodownload"
+video.controlsList; // "nofullscreen nodownload noplaybackrate" - "noremoteplayback" not present
+video.getAttribute('controlslist'); // "nofullscreen nodownload noplaybackrate"
 ```


### PR DESCRIPTION
As browser vendors are about to add playback speed controls to their native media player, it would be good if web developers could control the visibility of this new control.

Following [HTMLMediaElement.playbackRate](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/playbackRate) naming, this PR adds a new `noplaybackrate` supported token to `HTMLMediaElement.controlsList`.

<hr>

![image](https://user-images.githubusercontent.com/634478/118974519-349cc900-b973-11eb-896c-5e0f9c6104f2.png)
<p align="center">Safari Technology Preview Release 123 screenshot</p>

<hr>

![image](https://user-images.githubusercontent.com/634478/118974639-55fdb500-b973-11eb-918d-aa92a92f62d5.png)
<p align="center">Chrome Canary 92.0.4512.4 screenshot</p>

